### PR TITLE
feat: improve HMM regime detection to reduce detection lag

### DIFF
--- a/app/signals/hmm_dto.py
+++ b/app/signals/hmm_dto.py
@@ -33,19 +33,19 @@ class HMMRequestDTO(BaseModel):
         description="Lookback period for observable calculations",
     )
     p_stay_bull: float = Field(
-        default=0.80,
+        default=0.75,
         ge=0.0,
         le=0.99,
         description="Probability of staying in bull regime",
     )
     p_stay_bear: float = Field(
-        default=0.80,
+        default=0.75,
         ge=0.0,
         le=0.99,
         description="Probability of staying in bear regime",
     )
     p_stay_chop: float = Field(
-        default=0.60,
+        default=0.55,
         ge=0.0,
         le=0.99,
         description="Probability of staying in chop regime",
@@ -59,6 +59,7 @@ class HMMRegimeDataPoint(BaseModel):
     close: float = Field(..., description="Close price")
     obs_momentum: float = Field(..., description="Standardized momentum observable")
     obs_volatility: float = Field(..., description="Standardized volatility observable")
+    obs_rsi: float = Field(..., description="Standardized RSI observable (centered at 50)")
     prob_bull: float = Field(..., ge=0, le=100, description="Bull regime probability (0-100)")
     prob_bear: float = Field(..., ge=0, le=100, description="Bear regime probability (0-100)")
     prob_chop: float = Field(..., ge=0, le=100, description="Chop regime probability (0-100)")

--- a/app/signals/hmm_service.py
+++ b/app/signals/hmm_service.py
@@ -91,6 +91,7 @@ async def get_hmm_regime_data(
                 close=float(row['Close']),
                 obs_momentum=float(row['obs_momentum']),
                 obs_volatility=float(row['obs_volatility']),
+                obs_rsi=float(row['obs_rsi']),
                 prob_bull=float(row['prob_bull']),
                 prob_bear=float(row['prob_bear']),
                 prob_chop=float(row['prob_chop']),

--- a/app/signals/signals_generator/hmm_signals.py
+++ b/app/signals/signals_generator/hmm_signals.py
@@ -5,9 +5,9 @@ Based on Pine Script: "Hidden Markov Model: Regime Probability [AlgoPoint]"
 Implements a 3-state HMM (Bull, Bear, Chop) with Bayesian updating.
 
 Regime characteristics:
-- Bull: Positive momentum (μ=1.0, σ=1.0), lower volatility (μ=-0.5, σ=1.0)
-- Bear: Negative momentum (μ=-1.0, σ=1.0), higher volatility (μ=1.0, σ=1.0)
-- Chop: Low momentum (μ=0.0, σ=0.5), high volatility (μ=1.5, σ=1.0)
+- Bull: Positive momentum (μ=1.0, σ=1.5), lower volatility (μ=-0.5, σ=1.0), RSI above median (μ=0.8, σ=1.0)
+- Bear: Negative momentum (μ=-1.0, σ=1.5), higher volatility (μ=1.0, σ=1.0), RSI below median (μ=-0.8, σ=1.0)
+- Chop: Low momentum (μ=0.0, σ=0.5), high volatility (μ=1.5, σ=1.0), RSI near median (μ=0.0, σ=0.8)
 """
 
 import numpy as np
@@ -16,11 +16,11 @@ import pandas_ta as ta
 from typing import Literal
 
 
-# Regime parameters (mean and std for both momentum and volatility)
+# Regime parameters (mean and std for momentum, volatility, and RSI observables)
 REGIME_PARAMS = {
-    'bull': {'mom_mu': 1.0, 'mom_sigma': 1.0, 'vol_mu': -0.5, 'vol_sigma': 1.0},
-    'bear': {'mom_mu': -1.0, 'mom_sigma': 1.0, 'vol_mu': 1.0, 'vol_sigma': 1.0},
-    'chop': {'mom_mu': 0.0, 'mom_sigma': 0.5, 'vol_mu': 1.5, 'vol_sigma': 1.0},
+    'bull': {'mom_mu': 1.0,  'mom_sigma': 1.5, 'vol_mu': -0.5, 'vol_sigma': 1.0, 'rsi_mu':  0.8, 'rsi_sigma': 1.0},
+    'bear': {'mom_mu': -1.0, 'mom_sigma': 1.5, 'vol_mu':  1.0, 'vol_sigma': 1.0, 'rsi_mu': -0.8, 'rsi_sigma': 1.0},
+    'chop': {'mom_mu':  0.0, 'mom_sigma': 0.5, 'vol_mu':  1.5, 'vol_sigma': 1.0, 'rsi_mu':  0.0, 'rsi_sigma': 0.8},
 }
 
 
@@ -47,9 +47,9 @@ def gaussian_pdf(x: float, mu: float, sigma: float) -> float:
 def calculate_hmm_regime(
     df: pd.DataFrame,
     length: int = 20,
-    p_stay_bull: float = 0.80,
-    p_stay_bear: float = 0.80,
-    p_stay_chop: float = 0.60,
+    p_stay_bull: float = 0.75,
+    p_stay_bear: float = 0.75,
+    p_stay_chop: float = 0.55,
 ) -> pd.DataFrame:
     """
     Calculate HMM regime probabilities for market data.
@@ -61,14 +61,15 @@ def calculate_hmm_regime(
     Args:
         df: DataFrame with OHLCV data (must have 'Close', 'High', 'Low' columns)
         length: Lookback period for observable calculations (default: 20)
-        p_stay_bull: Probability of staying in bull regime (default: 0.80)
-        p_stay_bear: Probability of staying in bear regime (default: 0.80)
-        p_stay_chop: Probability of staying in chop regime (default: 0.60)
+        p_stay_bull: Probability of staying in bull regime (default: 0.75)
+        p_stay_bear: Probability of staying in bear regime (default: 0.75)
+        p_stay_chop: Probability of staying in chop regime (default: 0.55)
 
     Returns:
         DataFrame with additional columns:
         - obs_momentum: Standardized momentum observable
         - obs_volatility: Standardized volatility observable
+        - obs_rsi: Standardized RSI observable (centered at 50)
         - prob_bull: Bull regime probability (0-100)
         - prob_bear: Bear regime probability (0-100)
         - prob_chop: Chop regime probability (0-100)
@@ -85,39 +86,54 @@ def calculate_hmm_regime(
     if missing_cols:
         raise ValueError(f"Missing required columns: {missing_cols}")
 
-    if len(df) < length + 1:
-        raise ValueError(f"Insufficient data: need at least {length + 1} rows, got {len(df)}")
+    min_required = max(length, 14) + max(10, length // 2) + 1
+    if len(df) < min_required:
+        raise ValueError(f"Insufficient data: need at least {min_required} rows, got {len(df)}")
 
     df = df.copy()
+
+    # Shared normalization window (shorter than length to reduce lag)
+    norm_window = max(10, length // 2)
 
     # ==========================================
     # Observable 1: Momentum
     # ==========================================
-    # Calculate rate of change
-    mom_raw = ta.roc(df['Close'], length=1)
-
-    # Smooth with EMA
-    mom_smooth = ta.ema(mom_raw, length=length)
+    # Use multi-period ROC directly — inherently smoother than ROC(1)+EMA,
+    # and avoids the ~(length/2)-bar lag that EMA smoothing introduced.
+    roc_length = max(3, length // 4)
+    mom_raw = ta.roc(df['Close'], length=roc_length)
 
     # Standardize: (value - mean) / std; NaN where std == 0 or during warm-up
-    mom_std = ta.stdev(mom_smooth, length=length)
-    mom_mean = ta.sma(mom_smooth, length=length)
-    df['obs_momentum'] = np.where(mom_std != 0, (mom_smooth - mom_mean) / mom_std, np.nan)
+    mom_std = ta.stdev(mom_raw, length=norm_window)
+    mom_mean = ta.sma(mom_raw, length=norm_window)
+    df['obs_momentum'] = np.where(mom_std != 0, (mom_raw - mom_mean) / mom_std, np.nan)
 
     # ==========================================
     # Observable 2: Volatility
     # ==========================================
-    # Calculate ATR
-    vol_raw = ta.atr(df['High'], df['Low'], df['Close'], length=length)
+    # Use shorter ATR period for faster volatility response
+    atr_length = max(5, length // 2)
+    vol_raw = ta.atr(df['High'], df['Low'], df['Close'], length=atr_length)
 
     # Standardize; NaN where std == 0 or during warm-up
-    vol_std = ta.stdev(vol_raw, length=length)
-    vol_mean = ta.sma(vol_raw, length=length)
+    vol_std = ta.stdev(vol_raw, length=norm_window)
+    vol_mean = ta.sma(vol_raw, length=norm_window)
     df['obs_volatility'] = np.where(vol_std != 0, (vol_raw - vol_mean) / vol_std, np.nan)
+
+    # ==========================================
+    # Observable 3: RSI
+    # ==========================================
+    # RSI is a fast bounded oscillator; centering at 50 gives positive values
+    # for bullish conditions and negative for bearish.
+    rsi_raw = ta.rsi(df['Close'], length=14)
+    rsi_centered = rsi_raw - 50.0
+    rsi_std = ta.stdev(rsi_centered, length=norm_window)
+    rsi_mean = ta.sma(rsi_centered, length=norm_window)
+    df['obs_rsi'] = np.where(rsi_std != 0, (rsi_centered - rsi_mean) / rsi_std, np.nan)
 
     # Drop warm-up rows where indicators couldn't be computed (avoids biasing
     # the HMM with artificial zeros during the look-back initialisation period)
-    df = df.dropna(subset=['obs_momentum', 'obs_volatility']).copy()
+    df = df.dropna(subset=['obs_momentum', 'obs_volatility', 'obs_rsi']).copy()
     if len(df) == 0:
         raise ValueError("Insufficient data after removing warmup period")
 
@@ -130,17 +146,20 @@ def calculate_hmm_regime(
 
     df['like_bull'] = (
         gaussian_pdf(df['obs_momentum'], bull_params['mom_mu'], bull_params['mom_sigma']) *
-        gaussian_pdf(df['obs_volatility'], bull_params['vol_mu'], bull_params['vol_sigma'])
+        gaussian_pdf(df['obs_volatility'], bull_params['vol_mu'], bull_params['vol_sigma']) *
+        gaussian_pdf(df['obs_rsi'], bull_params['rsi_mu'], bull_params['rsi_sigma'])
     )
 
     df['like_bear'] = (
         gaussian_pdf(df['obs_momentum'], bear_params['mom_mu'], bear_params['mom_sigma']) *
-        gaussian_pdf(df['obs_volatility'], bear_params['vol_mu'], bear_params['vol_sigma'])
+        gaussian_pdf(df['obs_volatility'], bear_params['vol_mu'], bear_params['vol_sigma']) *
+        gaussian_pdf(df['obs_rsi'], bear_params['rsi_mu'], bear_params['rsi_sigma'])
     )
 
     df['like_chop'] = (
         gaussian_pdf(df['obs_momentum'], chop_params['mom_mu'], chop_params['mom_sigma']) *
-        gaussian_pdf(df['obs_volatility'], chop_params['vol_mu'], chop_params['vol_sigma'])
+        gaussian_pdf(df['obs_volatility'], chop_params['vol_mu'], chop_params['vol_sigma']) *
+        gaussian_pdf(df['obs_rsi'], chop_params['rsi_mu'], chop_params['rsi_sigma'])
     )
 
     # ==========================================

--- a/tests/test_hmm_signals.py
+++ b/tests/test_hmm_signals.py
@@ -84,6 +84,7 @@ class TestCalculateHMMRegime:
         expected_cols = [
             'obs_momentum',
             'obs_volatility',
+            'obs_rsi',
             'prob_bull',
             'prob_bear',
             'prob_chop',
@@ -173,6 +174,11 @@ class TestCalculateHMMRegime:
         ).all()
         assert momentum_within_bounds, "Momentum observable outside expected range"
 
+        rsi_within_bounds = (
+            (result['obs_rsi'] > -5) & (result['obs_rsi'] < 5)
+        ).all()
+        assert rsi_within_bounds, "RSI observable outside expected range"
+
     def test_likelihood_columns_exist(self, sample_ohlcv_data):
         """Should calculate likelihood columns for each regime."""
         result = calculate_hmm_regime(sample_ohlcv_data, length=20)
@@ -188,6 +194,13 @@ class TestCalculateHMMRegime:
         assert (result['like_bull'] >= 0).all()
         assert (result['like_bear'] >= 0).all()
         assert (result['like_chop'] >= 0).all()
+
+    def test_rsi_observable_is_finite(self, sample_ohlcv_data):
+        """obs_rsi should be present and contain finite values after warm-up drop."""
+        result = calculate_hmm_regime(sample_ohlcv_data, length=20)
+        assert 'obs_rsi' in result.columns
+        assert result['obs_rsi'].notna().all(), "obs_rsi contains NaN after dropna"
+        assert np.isfinite(result['obs_rsi']).all(), "obs_rsi contains non-finite values"
 
 
 class TestHMMToSignal:
@@ -273,9 +286,12 @@ class TestRegimeParams:
             assert 'mom_sigma' in params
             assert 'vol_mu' in params
             assert 'vol_sigma' in params
+            assert 'rsi_mu' in params
+            assert 'rsi_sigma' in params
 
     def test_positive_standard_deviations(self):
         """All standard deviations should be positive."""
         for regime, params in REGIME_PARAMS.items():
             assert params['mom_sigma'] > 0
             assert params['vol_sigma'] > 0
+            assert params['rsi_sigma'] > 0


### PR DESCRIPTION
- Replace ROC(1)+EMA(length) momentum with ROC(length//4) to eliminate
  the ~(length/2)-bar lag from EMA smoothing
- Use ATR(length//2) and shorter norm_window (length//2) for volatility,
  halving the lag on the volatility observable
- Add RSI as a third observable (centered at 50, standardized) to better
  discriminate bull/bear from chop when both have elevated volatility
- Widen mom_sigma for bull/bear (1.0→1.5) to match the broader distribution
  of the shorter ROC period
- Lower default p_stay values (bull/bear: 0.80→0.75, chop: 0.60→0.55) to
  reduce transition inertia and allow faster regime switching
- Update minimum data check to account for RSI(14) warm-up period
- Expose obs_rsi in HMMRegimeDataPoint DTO and API response
- Update tests: 4 updated + 1 new test (25 total, all passing)

https://claude.ai/code/session_0197QZXFFJHvXjr7kLBZ482p