### PR TITLE
fix: prevent replay endpoint thread-pool exhaustion via yfinance timeout

### DIFF
--- a/app/signals/service.py
+++ b/app/signals/service.py
@@ -33,6 +33,8 @@ from app.signals.utils.yfinance import getYFinanceData, getYFinanceDataAsync
 
 executor = ThreadPoolExecutor(max_workers=5)
 
+REPLAY_TIMEOUT_SECONDS = 120
+
 
 def safe_float(value, default=0.0, decimals=3):
     """Safely convert a value to float, handling NaN and None values."""
@@ -554,7 +556,10 @@ async def replay_backtest(backtest_id: int):
         return replay_backtest_func(df, trade_schedule)
 
     try:
-        bt, stats, trade_actions, strategy_parameters = await asyncio.to_thread(_run_replay)
+        bt, stats, trade_actions, strategy_parameters = await asyncio.wait_for(
+            asyncio.to_thread(_run_replay),
+            timeout=REPLAY_TIMEOUT_SECONDS,
+        )
         if bt is None or stats is None:
             print("[REPLAY] Backtest returned None")
             raise HTTPException(
@@ -562,6 +567,17 @@ async def replay_backtest(backtest_id: int):
                 detail="Backtest replay returned no results.",
             )
         print(f"[REPLAY] Backtest completed successfully")
+    except asyncio.TimeoutError:
+        logging.error(
+            "Replay timed out after %ss. backtest_id=%s",
+            REPLAY_TIMEOUT_SECONDS,
+            backtest_id,
+        )
+        raise HTTPException(
+            status_code=408,
+            detail=f"Backtest replay timed out after {REPLAY_TIMEOUT_SECONDS}s. "
+            "The data source may be stalled — try again.",
+        )
     except HTTPException:
         raise
     except Exception as e:
@@ -582,7 +598,21 @@ async def replay_backtest(backtest_id: int):
         print(f"[REPLAY] HTML ends with: {content[-200:]}")
         return content
 
-    html_content = await asyncio.to_thread(_render_html)
+    try:
+        html_content = await asyncio.wait_for(
+            asyncio.to_thread(_render_html),
+            timeout=REPLAY_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logging.error(
+            "Replay HTML render timed out after %ss. backtest_id=%s",
+            REPLAY_TIMEOUT_SECONDS,
+            backtest_id,
+        )
+        raise HTTPException(
+            status_code=408,
+            detail=f"Backtest replay timed out after {REPLAY_TIMEOUT_SECONDS}s during HTML render.",
+        )
     logging.info("replay_backtest finished")
 
     # Compress the HTML to match the format stored in the DB (zlib + base64).

--- a/app/signals/utils/yfinance.py
+++ b/app/signals/utils/yfinance.py
@@ -4,6 +4,8 @@ import pytz
 import yfinance as yf
 import pandas as pd
 
+_YFINANCE_DOWNLOAD_TIMEOUT_SECONDS = 20
+
 def get_dates(period):
   utc = datetime.now(pytz.utc)
   tz = pytz.timezone("Asia/Singapore")
@@ -33,10 +35,15 @@ def getYFinanceData(ticker, interval, period=None, start=None, end=None):
   period = int(period[:-1])
   end, start = get_dates(period)
 
-  if period != None:
-    dataF = yf.download(tickers=ticker, interval=interval, start=start, end=end, multi_level_index = False, auto_adjust=True)
-  else:
-    dataF = yf.download(tickers=ticker, interval=interval, start=start, end=end, multi_level_index = False, auto_adjust=True)
+  dataF = yf.download(
+    tickers=ticker,
+    interval=interval,
+    start=start,
+    end=end,
+    multi_level_index=False,
+    auto_adjust=True,
+    timeout=_YFINANCE_DOWNLOAD_TIMEOUT_SECONDS,
+  )
 
   dataF.iloc[:, :]
 

--- a/tests/test_yfinance_timeout.py
+++ b/tests/test_yfinance_timeout.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from app.signals.utils import yfinance as yfinance_module
+from app.signals.utils.yfinance import _YFINANCE_DOWNLOAD_TIMEOUT_SECONDS, getYFinanceData
+
+
+def _fake_yf_frame() -> pd.DataFrame:
+    idx = pd.DatetimeIndex(
+        [pd.Timestamp("2024-01-01 10:00:00"), pd.Timestamp("2024-01-01 11:00:00")],
+        name="Datetime",
+    )
+    return pd.DataFrame(
+        {
+            "Open": [100.0, 101.0],
+            "High": [102.0, 103.0],
+            "Low": [99.0, 100.0],
+            "Close": [100.5, 101.5],
+            "Volume": [1000, 2000],
+        },
+        index=idx,
+    )
+
+
+def test_get_yfinance_data_passes_timeout_to_download(monkeypatch):
+    captured: dict = {}
+
+    def fake_download(**kwargs):
+        captured.update(kwargs)
+        return _fake_yf_frame()
+
+    monkeypatch.setattr(yfinance_module.yf, "download", fake_download)
+
+    df = getYFinanceData(ticker="BTC-USD", interval="60m", period="5d")
+
+    assert "timeout" in captured
+    assert captured["timeout"] == _YFINANCE_DOWNLOAD_TIMEOUT_SECONDS
+    assert captured["timeout"] is not None
+    assert not df.empty


### PR DESCRIPTION
## Problem

`/signals/backtest/replay?backtest_id=...` hangs forever ("pending") in production, while the server itself stays responsive (`/`, `/signals/strategies` return in ~2 ms).

## Root cause

`getYFinanceData` (`app/signals/utils/yfinance.py`) called `yf.download()` **with no `timeout=`**. When a Yahoo Finance connection stalls, the call blocks indefinitely inside an `asyncio.to_thread` worker thread. Because Python threads cannot be force-killed, `asyncio.wait_for` (even the existing 600 s deadline on the optimization backtest) only cancels the *await* — the underlying thread keeps leaking. Over weeks of uptime these leaked threads **exhausted uvicorn's default thread pool**, so every new `asyncio.to_thread` call (including replay) queues forever.

Confirmed by reproduction:
- Direct call `replay_backtest(286)` in a fresh process → **200 in 6.8 s** (logic is fine).
- Same call over HTTP in the long-running process → hangs indefinitely.
- Logs stall exactly at `await asyncio.to_thread(_run_replay)` (line 557), after `Found 115 trade actions to replay`.
- Restarting the container cleared the stuck threads and restored the endpoint.

## Fix

**1. `app/signals/utils/yfinance.py` — root-cause fix**
- Add `_YFINANCE_DOWNLOAD_TIMEOUT_SECONDS = 20` and pass `timeout=` to `yf.download()`.
- This is the only `yf.download()` site in the app, so it covers every caller (`service.py`, `hmm_service.py`). A stall now returns an empty frame → existing `ValueError("No data returned from yfinance...")` → HTTP 400, and the thread is freed.

**2. `app/signals/service.py` — backstop / UX**
- Add `REPLAY_TIMEOUT_SECONDS = 120` and wrap `replay_backtest`'s two `asyncio.to_thread` calls in `asyncio.wait_for(..., timeout=...)`, mirroring the existing 600 s backtest pattern (`service.py:152`).
- On timeout → `HTTPException(408)` instead of an infinite hang.

Note: Fix 2 alone would **not** prevent recurrence (it can't kill the thread) — Fix 1 is what stops the leak. They are complementary.

## Verification
- `ruff check` / `black --check`: no new violations introduced (remaining ones. `pytest -m "not integration"`: **122 passed, 1 skipped** (incl. new test).
- New unit test `tests/test_yfinance_timeout.py` monkeypatches `yf.download` and asserts `timeout` is passed through.

## Out of scope (separate PR)
`getYFinanceData` ignores the passed `start`/`end` args and recomputes them from `period` relative to `datetime.now()`. A latent correctness bug affecting all yfinance callers — left for a separate PR to keep this outage fix focused.

## Manual verification (post-deploy)
```
GET /signals/backtest/replay?backtest_id=286  →  HTTP 200 in ~7 s
```