### PR TITLE
fix: prevent duplicate backtest HTML writes

### DIFF
--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -70,7 +70,11 @@ class BacktestStatRepository:
             # so we never need to issue a get_by_id() SELECT (which would load html).
             return SimpleNamespace(
                 id=existing.id,
-                notifications_on=update_data.get("notifications_on"),
+                notifications_on=(
+                    update_data["notifications_on"]
+                    if "notifications_on" in update_data
+                    else existing.notifications_on
+                ),
             )
         else:
             return await self.insert(data)
@@ -87,6 +91,19 @@ class BacktestStatRepository:
         stmt = select(BacktestStat).where(BacktestStat.id == backtest_id)
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def get_replay_metadata(self, backtest_id: int):
+        """Return only the fields needed to replay a backtest."""
+        stmt = select(
+            BacktestStat.ticker,
+            BacktestStat.strategy,
+            BacktestStat.interval,
+            BacktestStat.period,
+            BacktestStat.start_time,
+            BacktestStat.end_time,
+        ).where(BacktestStat.id == backtest_id)
+        result = await self._session.execute(stmt)
+        return result.first()
 
 
 # ---------------------------------------------------------------------------

--- a/app/signals/service.py
+++ b/app/signals/service.py
@@ -471,8 +471,8 @@ async def replay_backtest(backtest_id: int):
         backtest_repo = BacktestStatRepository(session)
         trade_repo = TradeActionRepository(session)
 
-        # Get the BacktestStat
-        backtest_stat = await backtest_repo.get_by_id(backtest_id)
+        # Get only the metadata needed for replay; the stored HTML is not used here.
+        backtest_stat = await backtest_repo.get_replay_metadata(backtest_id)
         if backtest_stat is None:
             print(f"[REPLAY] Backtest with ID {backtest_id} not found")
             raise HTTPException(status_code=404, detail=f"Backtest with ID {backtest_id} not found")

--- a/tests/test_postgres_repository.py
+++ b/tests/test_postgres_repository.py
@@ -94,6 +94,28 @@ class TestBacktestStatRepository:
         assert fetched is not None
         assert fetched.sharpe_ratio == 2.5
 
+    async def test_upsert_preserves_existing_notifications_when_omitted(self, db_session):
+        repo = BacktestStatRepository(db_session)
+        stat = await repo.insert(_backtest_payload(ticker="MSFT", notifications_on=True))
+        update = _backtest_payload(ticker="MSFT", sharpe_ratio=2.0)
+        update.pop("notifications_on")
+
+        updated = await repo.upsert(update)
+
+        assert updated is not None
+        assert updated.id == stat.id
+        assert updated.notifications_on is True
+
+    async def test_get_replay_metadata_excludes_html(self, db_session):
+        repo = BacktestStatRepository(db_session)
+        stat = await repo.insert(_backtest_payload(ticker="TSLA", html="large-chart"))
+
+        metadata = await repo.get_replay_metadata(stat.id)
+
+        assert metadata is not None
+        assert metadata.ticker == "TSLA"
+        assert not hasattr(metadata, "html")
+
     async def test_insert_multiple_records(self, db_session):
         repo = BacktestStatRepository(db_session)
         for i in range(3):


### PR DESCRIPTION
## What changed
- preserve the existing notifications_on value when an upsert payload omits it
- prevent the notification job from issuing a second full HTML upsert
- fetch only the six metadata columns needed by backtest replay
- add regressions for omitted notification state and HTML-free replay metadata

## Root cause
The prior egress optimization selected notifications_on separately, but the slim update result discarded that selected value. The persistence service interpreted the resulting None as uninitialized state and repeated the full upsert, including the compressed HTML chart.

## Impact
Scheduled backtests now perform one HTML write instead of two, and replay no longer reads stored HTML it does not use.

## Validation
- .venv/bin/pytest -q — 124 passed, 1 skipped
- .venv/bin/ruff check app/db/repository.py tests/test_postgres_repository.py
- git diff --check

Repository-wide Ruff has existing violations in app/signals/service.py unrelated to this change.